### PR TITLE
fixed linkdef to follow root6 syntax. 

### DIFF
--- a/src/template-project_LinkDef.h
+++ b/src/template-project_LinkDef.h
@@ -1,11 +1,11 @@
 #ifndef template_project_LinkDef_h
 #define template_project_LinkDef_h
 
-#ifdef __CINT__
+#ifdef __CLING__
 
 // HelloWorld.h
-#pragma link C++ class tmplns::HelloWorld-;
+#pragma link C++ class tmplns::HelloWorld-!;
 
-#endif // __CINT__
+#endif // __CLING__
 
 #endif // template_project_LinkDef_h


### PR DESCRIPTION
Migrated linkdef from cint to cling plus added new ! operator. Starting from root 6:

"-" : tells rootcling not to generate the Streamer method for this class. This is necessary for those classes that need a customized Streamer method.

"!": tells rootcling not to generate the operator>>(TBuffer &b,MyClass *&obj) method for this class. This is necessary to be able to write pointers to objects of classes not inheriting from TObject.

(cut and paste from https://root.cern.ch/root/htmldoc/guides/users-guide/ROOTUsersGuide.html#the-linkdef.h-file)
  